### PR TITLE
[FIX] 스탯 래퍼 클래스에서 분리 및 스킬 인가 범위 수정

### DIFF
--- a/Assets/Scripts/Actor/ActorController.cs
+++ b/Assets/Scripts/Actor/ActorController.cs
@@ -89,7 +89,8 @@ namespace Actor
         public void Hitted(float damage, IBuff buff = null)
         {
             Debug.Log($"{damage} 맞아부럿성...");
-            _stat.HP.AddStat(-damage);
+            _stat.hp -= damage;
+            Debug.Log("값이우찌되오" + _stat.hp);
             _stateMachine.ChangeState(States.OnHitted);
         }
     }

--- a/Assets/Scripts/Actor/Buff/MaxHPUpBuff.cs
+++ b/Assets/Scripts/Actor/Buff/MaxHPUpBuff.cs
@@ -19,12 +19,12 @@ public class MaxHPUpBuff : IBuff
     public void OnBuff()
     {
         _stat.MaxHP.percent += 0.1f;
-        _stat.ATK.percent += 0.1f;
+        _stat.Atk.percent += 0.1f;
     }
 
     public void OffBuff()
     {
         _stat.MaxHP.percent -= 0.1f;
-        _stat.ATK.percent -= 0.1f;
+        _stat.Atk.percent -= 0.1f;
     }
 }

--- a/Assets/Scripts/Actor/Skill/ChainFireBall.cs
+++ b/Assets/Scripts/Actor/Skill/ChainFireBall.cs
@@ -38,7 +38,6 @@ namespace Actor.Skill
             for (int i = 0; i < 3; i++)
             {
                 Generate(id, 0);
-                Debug.Log("아니와이라노!!");
                 projectileList[id][i].Init(_stat, primaryDirection, primaryPosition, new Vector3(1f, 0.7f, 0f), 1.2f, new Vector3(10f, 0f, 0f));
                 projectileList[id][i].Fire();
                 yield return new WaitForSeconds(0.7f);

--- a/Assets/Scripts/Actor/Skill/FireBall.cs
+++ b/Assets/Scripts/Actor/Skill/FireBall.cs
@@ -23,7 +23,7 @@ namespace Actor.Skill
         {
             if (!HasStateAuthority) return;
             if (target == null) return;
-            target.Hitted(_stat.ATK.Value);
+            target.Hitted(_stat.atk);
             //Pierce();
             Runner.Despawn(gameObject.GetComponent<NetworkObject>());
         }

--- a/Assets/Scripts/Actor/Skill/ISkill.cs
+++ b/Assets/Scripts/Actor/Skill/ISkill.cs
@@ -16,11 +16,11 @@ public abstract class ISkill : NetworkBehaviour
     //너무 결합도 높은가 싶음... 쿨타임 UI를 그냥 Action으로 옮기는 것도 괜찮을지도...
     protected IEnumerator CoolDown(float coolTime)
     {
+        if(HasStateAuthority) _canUse = false;
         _anim.speed = 1 / coolTime;
-        _canUse = false;
         _anim.Play("CoolTime");
         yield return new WaitForSeconds(coolTime);
-        _canUse = true;
+        if(HasStateAuthority) _canUse = true;
         _anim.Play("New State");
     }
 }

--- a/Assets/Scripts/Actor/Stat/FluidStat.cs
+++ b/Assets/Scripts/Actor/Stat/FluidStat.cs
@@ -11,10 +11,10 @@ public class FluidStat : Stat
 
     public void AddStat(float value)
     {
-        SetStat(_value + value);
+        SetValue(_value + value);
     }
 
-    public void SetStat(float value)
+    public override void SetValue(float value)
     {
         this._value = value;
         StatChanged?.Invoke();

--- a/Assets/Scripts/Actor/Stat/Stat.cs
+++ b/Assets/Scripts/Actor/Stat/Stat.cs
@@ -14,6 +14,11 @@ public class Stat
         }
     }
 
+    public virtual void SetValue(float value)
+    {
+        _value = value;
+    }
+
     public Stat(float value)
     {
         _value = value;

--- a/Assets/Scripts/Actor/WrapBody.cs
+++ b/Assets/Scripts/Actor/WrapBody.cs
@@ -88,6 +88,7 @@ public class WrapBody : NetworkBehaviour
             //가속 구현 -> isPressing
             velocity = directionX * _stat.moveSpeed * _stat.speed * Runner.DeltaTime;
 
+            Debug.Log(velocity);
             if (isDashing)
             {
                 velocity = beforeDirectionX * _stat.speed * dashVelocity * Runner.DeltaTime;

--- a/Assets/Scripts/UI/Scene/StatusUIController.cs
+++ b/Assets/Scripts/UI/Scene/StatusUIController.cs
@@ -12,7 +12,7 @@ namespace UI.Scene
         {
             _view = GetComponent<UI_Status>();
             _model = GameObject.FindWithTag("Player").GetOrAddComponent<ActorStat>();
-            _model.HP.StatChanged += delegate { _view.UpdateHp(_model.MaxHP.Value, _model.HP.Value); };
+            _model.HpStatChanged += delegate { _view.UpdateHp(_model.maxHP, _model.hp); };
         }
         
         public override void Spawned()


### PR DESCRIPTION
- (금) Stat 동기화 문제 해결

기존 Stat - Fluid Stat, Game Stat 클래스로 스탯을 래핑했는데 래퍼 클래스 네트워크 동기화가 불가능해 전부 풀었음.